### PR TITLE
add `payment_method` property to unmarshalled struct

### DIFF
--- a/charge.go
+++ b/charge.go
@@ -74,6 +74,7 @@ type Charge struct {
 	Meta           map[string]string `json:"metadata"`
 	Outcome        *ChargeOutcome    `json:"outcome"`
 	Paid           bool              `json:"paid"`
+	PaymentMethod  string            `json:"payment_method"`
 	Refunded       bool              `json:"refunded"`
 	Refunds        *RefundList       `json:"refunds"`
 	Shipping       *ShippingDetails  `json:"shipping"`


### PR DESCRIPTION
Our version of the Stripe Library doesn't recognize this property and there's an issue in #ops-errors we need it for. Upgrading the library a week before we drop it would create hundreds of required changes across API, so we go back to our old fork (which I updated to match the version we use) and make this change.
